### PR TITLE
Add message queue and worker deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,31 +58,35 @@ LOG_LEVEL=INFO
 
 ### Basic Usage
 
-Run the A1 system on a list of target contracts:
+Contract addresses are distributed to workers through a RabbitMQ queue.  To
+process jobs locally, start a worker pointed at the queue:
 
 ```bash
-python main.py --targets targets.txt
+python workers/analyzer_worker.py
 ```
+
+To analyse a single contract without the queue, pass the address directly:
+
+```bash
+python main.py --contract 0x1234567890123456789012345678901234567890
+```
+
+### Enqueuing Contracts
+
+Producers can enqueue jobs using the :mod:`core.queue` module or any AMQP
+client.  Each job is a JSON object with ``address`` and ``network`` fields.
 
 ### Advanced Options
 
 ```bash
-# Run with custom configuration
-python main.py --targets targets.txt --max-iterations 3 --output-dir ./custom_results
+# Run worker with higher concurrency
+A1_WORKER_CONCURRENCY=5 python workers/analyzer_worker.py
 
-# Run on a single contract
-python main.py --contract 0x1234567890123456789012345678901234567890
+# Specify custom queue location
+python main.py --queue-url amqp://guest:guest@localhost/ --queue-name contract_targets
 
 # Run with verbose logging
-python main.py --targets targets.txt --log-level DEBUG
-```
-
-### Target File Format
-
-Create a `targets.txt` file with one contract address per line:
-```
-0x1234567890123456789012345678901234567890
-0xabcdefabcdefabcdefabcdefabcdefabcdefabcd
+python main.py --contract 0x1234... --verbose
 ```
 
 ### Simple Test
@@ -136,6 +140,47 @@ Key configuration options in `.env`:
 4. **Code Sanitizer**: Cleans and optimizes contract code for analysis
 5. **Concrete Execution**: Simulates exploits using Foundry/Forge
 6. **Revenue Normalizer**: Calculates economic profitability with real-time prices
+
+## 🚀 Deployment
+
+Multiple workers can consume contracts from the shared queue.  This allows the
+analysis to scale across machines.
+
+### systemd
+
+```ini
+[Unit]
+Description=A1 analyzer worker
+After=network.target
+
+[Service]
+Environment=QUEUE_URL=amqp://user:pass@mq/
+ExecStart=/usr/bin/python workers/analyzer_worker.py
+Restart=always
+
+[Install]
+WantedBy=multi-user.target
+```
+
+### Kubernetes
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: a1-worker
+spec:
+  replicas: 3
+  template:
+    spec:
+      containers:
+      - name: worker
+        image: your-image
+        env:
+        - name: QUEUE_URL
+          value: amqp://user:pass@rabbitmq/
+        command: ["python", "workers/analyzer_worker.py"]
+```
 
 ## 🧪 Testing
 

--- a/core/agent.py
+++ b/core/agent.py
@@ -18,6 +18,8 @@ import logging
 import openai
 from openai import AsyncOpenAI
 
+from core.queue import ContractQueue, QueueItem
+
 from tools.source_code_fetcher import SourceCodeFetcher
 from tools.constructor_parameter import ConstructorParameterTool
 from tools.state_reader import BlockchainStateReader
@@ -86,31 +88,38 @@ class A1Agent:
     through iterative refinement with 5-iteration budget management.
     """
     
-    def __init__(self, config: Dict[str, Any]):
+    def __init__(self, config: Dict[str, Any], queue: Optional[ContractQueue] = None):
+        """Initialize the A1 Agent.
+
+        Parameters
+        ----------
+        config:
+            Configuration dictionary with API keys and settings.
+        queue:
+            Optional :class:`ContractQueue` instance.  When provided the agent is
+            able to pull analysis targets directly from the queue when a target
+            address is not explicitly supplied.
         """
-        Initialize the A1 Agent.
-        
-        Args:
-            config: Configuration dictionary with API keys and settings
-        """
+
         self.config = config
-        
+        self.queue = queue
+
         self.grok_client = AsyncOpenAI(
             api_key=config.get('GROK_API_KEY'),
             base_url=config.get('GROK_BASE_URL', 'https://api.x.ai/v1')
         )
-        
+
         self.tools = self._initialize_tools()
-        
+
         self.max_iterations = config.get('MAX_ITERATIONS', 5)
         self.base_budget_per_iteration = config.get('BASE_BUDGET_PER_ITERATION', 1000)
         self.diminishing_factor = config.get('DIMINISHING_FACTOR', 0.8)
         self.confidence_threshold = config.get('CONFIDENCE_THRESHOLD', 0.7)
-        
+
         self.state: Optional[AgentState] = None
-        
+
         self.phase_prompts = self._initialize_phase_prompts()
-        
+
         self.attention_weights = {
             'source_code': 1.0,
             'constructor_params': 0.8,
@@ -271,17 +280,27 @@ Provide final recommendations with confidence scores, profit projections, and ri
 """
         }
     
-    async def initialize_session(self, target_contract: str, chain: str = 'ethereum') -> str:
-        """
-        Initialize a new exploit generation session.
-        
+    async def initialize_session(self, target_contract: Optional[str] = None, chain: str = 'ethereum') -> str:
+        """Initialize a new exploit generation session.
+
+        If ``target_contract`` is ``None`` the agent attempts to retrieve the
+        next target from the configured :class:`ContractQueue`.
+
         Args:
-            target_contract: Target contract address
+            target_contract: Optional target contract address
             chain: Blockchain network ('ethereum' or 'bsc')
-            
+
         Returns:
             Session ID for tracking
         """
+
+        if target_contract is None:
+            if not self.queue:
+                raise ValueError("No target contract provided and no queue configured")
+            item: QueueItem = await self.queue.dequeue()
+            target_contract = item.address
+            chain = item.network
+
         session_id = f"a1_{int(time.time())}_{target_contract[:8]}"
         
         self.state = AgentState(
@@ -300,14 +319,16 @@ Provide final recommendations with confidence scores, profit projections, and ri
         logger.info(f"Initialized A1 session {session_id} for contract {target_contract}")
         return session_id
     
-    async def execute_full_analysis(self, target_contract: str, chain: str = 'ethereum') -> Dict[str, Any]:
-        """
-        Execute the complete 5-iteration exploit generation process.
-        
+    async def execute_full_analysis(self, target_contract: Optional[str] = None, chain: str = 'ethereum') -> Dict[str, Any]:
+        """Execute the complete 5-iteration exploit generation process.
+
+        When ``target_contract`` is ``None`` the agent will pull the next job
+        from its queue if one has been configured.
+
         Args:
-            target_contract: Target contract address
+            target_contract: Optional target contract address
             chain: Blockchain network
-            
+
         Returns:
             Complete analysis results with generated strategies
         """

--- a/core/queue.py
+++ b/core/queue.py
@@ -1,0 +1,95 @@
+"""Message queue utilities for distributing contract analysis jobs.
+
+This module provides a small abstraction over a message broker.  It supports
+RabbitMQ via :mod:`aio_pika` when a broker URL is supplied and falls back to an
+in-memory :class:`asyncio.Queue` for local testing.  Jobs consist of contract
+addresses and their associated network identifiers.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+from dataclasses import dataclass
+from typing import AsyncIterator, Optional
+
+try:  # pragma: no cover - optional dependency
+    import aio_pika
+except Exception:  # pragma: no cover - library may not be installed
+    aio_pika = None  # type: ignore
+
+
+@dataclass
+class QueueItem:
+    """Simple container for contract analysis jobs."""
+
+    address: str
+    network: str = "ethereum"
+
+
+class ContractQueue:
+    """Abstraction over a message queue used to distribute analysis jobs.
+
+    Parameters
+    ----------
+    url:
+        Connection URL for the message broker.  If omitted, an in-memory queue
+        is used which is suitable for tests or development environments.
+    queue_name:
+        Name of the queue inside the broker.
+    """
+
+    def __init__(self, url: Optional[str] = None, queue_name: str = "contract_targets"):
+        self.url = url
+        self.queue_name = queue_name
+        self._connection = None
+        self._channel = None
+        self._queue = None
+        self._local_queue: asyncio.Queue[QueueItem] = asyncio.Queue()
+
+    async def connect(self) -> None:
+        """Establish connection to the broker if a URL was supplied."""
+
+        if self.url and aio_pika:
+            self._connection = await aio_pika.connect_robust(self.url)
+            self._channel = await self._connection.channel()
+            self._queue = await self._channel.declare_queue(self.queue_name, durable=True)
+
+    async def close(self) -> None:
+        """Close any open broker connections."""
+
+        if self._connection:
+            await self._connection.close()
+            self._connection = None
+
+    async def enqueue(self, item: QueueItem) -> None:
+        """Add a job to the queue."""
+
+        if self._queue and aio_pika:
+            body = json.dumps(item.__dict__).encode()
+            message = aio_pika.Message(body=body)
+            await self._channel.default_exchange.publish(message, routing_key=self.queue_name)
+        else:
+            await self._local_queue.put(item)
+
+    async def dequeue(self) -> QueueItem:
+        """Remove a job from the queue, waiting if necessary."""
+
+        if self._queue and aio_pika:
+            message = await self._queue.get()
+            async with message.process():
+                data = json.loads(message.body.decode())
+                return QueueItem(**data)
+
+        return await self._local_queue.get()
+
+    async def consume(self) -> AsyncIterator[QueueItem]:
+        """Iterate over jobs as they arrive."""
+
+        while True:
+            item = await self.dequeue()
+            yield item
+
+
+__all__ = ["QueueItem", "ContractQueue"]
+

--- a/main.py
+++ b/main.py
@@ -23,6 +23,7 @@ from core.agent import A1Agent
 from core.orchestrator import ToolOrchestrator
 from core.feedback import FeedbackProcessor
 from core.strategy import StrategyGenerator
+from core.queue import ContractQueue, QueueItem
 
 from tools.source_code_fetcher import SourceCodeFetcher
 from tools.constructor_parameter import ConstructorParameterTool
@@ -606,6 +607,36 @@ class ContractProcessor:
         
         logger.info(f"Batch processing completed: {len(results)} results")
         return results
+
+    async def process_queue(self, queue: ContractQueue, max_concurrent: int = 3) -> None:
+        """Continuously process contracts from a message queue.
+
+        Args:
+            queue: :class:`ContractQueue` instance to pull jobs from.
+            max_concurrent: Maximum number of concurrent analyses.
+        """
+
+        if not self.is_initialized:
+            raise RuntimeError("System not initialized. Call initialize() first.")
+
+        semaphore = asyncio.Semaphore(max_concurrent)
+        active: set[asyncio.Task] = set()
+
+        async def handle(item: QueueItem):
+            async with semaphore:
+                target = ContractTarget(address=item.address, network=item.network)
+                await self.process_contract(target)
+
+        try:
+            async for item in queue.consume():
+                task = asyncio.create_task(handle(item))
+                active.add(task)
+                task.add_done_callback(lambda t: active.discard(t))
+        except asyncio.CancelledError:
+            pass
+
+        if active:
+            await asyncio.gather(*active)
     
     def get_performance_stats(self) -> Dict[str, Any]:
         """Get system performance statistics."""
@@ -697,7 +728,8 @@ async def main():
     parser = argparse.ArgumentParser(description="A1 Agentic System - Autonomous Smart Contract Exploit Generation")
     
     parser.add_argument('--config', '-c', default='.env', help='Configuration file path')
-    parser.add_argument('--targets', '-t', help='Targets file path')
+    parser.add_argument('--queue-url', help='AMQP URL for the contract queue')
+    parser.add_argument('--queue-name', default='contract_targets', help='Queue name')
     parser.add_argument('--contract', help='Single contract address to analyze')
     parser.add_argument('--network', default='ethereum', help='Network name (ethereum, bsc)')
     parser.add_argument('--max-concurrent', type=int, default=3, help='Maximum concurrent executions')
@@ -716,65 +748,37 @@ async def main():
     
     try:
         await processor.initialize()
-        
-        targets = []
-        
+
         if args.contract:
-            targets = [ContractTarget(
+            target = ContractTarget(
                 address=args.contract,
                 network=args.network,
                 name=f"Manual_{args.contract[:8]}"
-            )]
-        elif args.targets:
-            targets = await load_targets_from_file(args.targets)
-        else:
-            default_targets = Path(__file__).parent / "attachments" / "targets.txt"
-            if default_targets.exists():
-                targets = await load_targets_from_file(str(default_targets))
-            else:
-                logger.error("No targets specified. Use --contract or --targets")
-                return 1
-        
-        if not targets:
-            logger.error("No valid targets found")
-            return 1
-        
-        if len(targets) == 1:
+            )
             logger.info("Processing single contract...")
-            results = [await processor.process_contract(targets[0])]
-        else:
-            logger.info(f"Processing {len(targets)} contracts in batch mode...")
-            results = await processor.process_batch(targets, args.max_concurrent)
-        
-        successful = sum(1 for r in results if r.success)
-        total_exploits = sum(r.exploits_found for r in results)
-        total_profit = sum(r.total_profit_potential for r in results)
-        
-        logger.info(f"\n=== EXECUTION SUMMARY ===")
-        logger.info(f"Contracts processed: {len(results)}")
-        logger.info(f"Successful analyses: {successful}")
-        logger.info(f"Success rate: {successful/len(results)*100:.1f}%")
-        logger.info(f"Total exploits found: {total_exploits}")
-        logger.info(f"Total profit potential: ${total_profit:.2f}")
-        
-        if args.output:
-            output_data = {
-                "timestamp": datetime.now().isoformat(),
-                "summary": {
-                    "contracts_processed": len(results),
-                    "successful_analyses": successful,
-                    "total_exploits": total_exploits,
-                    "total_profit_potential": total_profit
-                },
-                "results": [asdict(r) for r in results],
-                "performance_stats": processor.get_performance_stats()
-            }
-            
-            with open(args.output, 'w') as f:
-                json.dump(output_data, f, indent=2, default=str)
-            
-            logger.info(f"Results saved to {args.output}")
-        
+            result = await processor.process_contract(target)
+
+            if args.output:
+                output_data = {
+                    "timestamp": datetime.now().isoformat(),
+                    "results": [asdict(result)],
+                    "performance_stats": processor.get_performance_stats()
+                }
+                with open(args.output, 'w') as f:
+                    json.dump(output_data, f, indent=2, default=str)
+                logger.info(f"Results saved to {args.output}")
+
+            return 0
+
+        if not args.queue_url:
+            logger.error("No contract or queue specified. Provide --contract or --queue-url")
+            return 1
+
+        queue = ContractQueue(args.queue_url, args.queue_name)
+        await queue.connect()
+
+        logger.info("Processing contracts from queue... press Ctrl+C to stop")
+        await processor.process_queue(queue, args.max_concurrent)
         return 0
         
     except KeyboardInterrupt:

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pytest-asyncio>=0.21.1
 black>=23.11.0
 flake8>=6.1.0
 mypy>=1.7.1
+aio-pika>=9.4.0

--- a/workers/__init__.py
+++ b/workers/__init__.py
@@ -1,0 +1,2 @@
+"""Worker entry points for distributed contract analysis."""
+

--- a/workers/analyzer_worker.py
+++ b/workers/analyzer_worker.py
@@ -1,0 +1,45 @@
+"""Worker entry point for processing contract analysis jobs from a queue.
+
+This worker can be deployed on multiple machines and supervised by systems
+like Kubernetes or ``systemd``.  Each worker pulls contract addresses from the
+shared message queue and launches an ``A1Agent`` instance to analyse them.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import os
+
+from config.configuration_manager import ConfigurationManager
+from core.queue import ContractQueue
+from main import ContractProcessor
+
+
+async def run_worker(concurrency: int = 3) -> None:
+    """Run the analyzer worker."""
+
+    config_manager = ConfigurationManager(os.environ.get("A1_CONFIG", ".env"))
+    config = config_manager.get_config()
+
+    queue_url = config.get("QUEUE_URL")
+    queue_name = config.get("QUEUE_NAME", "contract_targets")
+
+    queue = ContractQueue(queue_url, queue_name)
+    await queue.connect()
+
+    processor = ContractProcessor(config)
+    await processor.initialize()
+
+    await processor.process_queue(queue, concurrency)
+
+
+def main() -> None:
+    """Synchronous wrapper for running the worker."""
+
+    concurrency = int(os.environ.get("A1_WORKER_CONCURRENCY", "3"))
+    asyncio.run(run_worker(concurrency))
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- add `ContractQueue` abstraction using RabbitMQ with in-memory fallback
- refactor agent and main entrypoint to pull contract targets from queue
- introduce `analyzer_worker` entrypoint for parallel processing and document deployment via systemd or Kubernetes

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_b_68b0b994ea3c83219a48896e4e536928