### PR TITLE
Add contract analysis caching and CLI controls

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -347,7 +347,8 @@ Provide final recommendations with confidence scores, profit projections, and ri
                     'total_profit_potential': 0.0,
                     'confidence_score': 1.0,
                     'iterations_used': 0,
-                    'detailed_results': {}
+                    'detailed_results': {},
+                    'cached_result_id': cached_id
                 }
 
         logger.info(f"Starting full A1 analysis for {target_contract}")

--- a/core/agent.py
+++ b/core/agent.py
@@ -12,6 +12,7 @@ import asyncio
 import json
 import time
 from typing import Dict, List, Optional, Any, Tuple
+import hashlib
 from dataclasses import dataclass, asdict
 from enum import Enum
 import logging
@@ -81,19 +82,21 @@ class AgentState:
 class A1Agent:
     """
     Main A1 Agent Controller with Grok-4-0709 integration.
-    
+
     Implements the autonomous agent that orchestrates exploit generation
     through iterative refinement with 5-iteration budget management.
     """
-    
-    def __init__(self, config: Dict[str, Any]):
+
+    def __init__(self, config: Dict[str, Any], result_storage=None):
         """
         Initialize the A1 Agent.
-        
+
         Args:
             config: Configuration dictionary with API keys and settings
+            result_storage: ResultStorage instance for caching
         """
         self.config = config
+        self.result_storage = result_storage
         
         self.grok_client = AsyncOpenAI(
             api_key=config.get('GROK_API_KEY'),
@@ -300,51 +303,95 @@ Provide final recommendations with confidence scores, profit projections, and ri
         logger.info(f"Initialized A1 session {session_id} for contract {target_contract}")
         return session_id
     
-    async def execute_full_analysis(self, target_contract: str, chain: str = 'ethereum') -> Dict[str, Any]:
-        """
-        Execute the complete 5-iteration exploit generation process.
-        
-        Args:
-            target_contract: Target contract address
-            chain: Blockchain network
-            
-        Returns:
-            Complete analysis results with generated strategies
-        """
+    async def execute_full_analysis(self, target_contract: str, chain: str = 'ethereum', force: bool = False, reuse: bool = False) -> Dict[str, Any]:
+        """Execute the complete analysis process with optional caching."""
         session_id = await self.initialize_session(target_contract, chain)
-        
+
+        source_info = await self._fetch_source_code()
+        contract_info = None
+        if 'source_code' in source_info and 'abi' in source_info:
+            class ContractInfo:
+                def __init__(self, abi, source_code, contract_name):
+                    self.abi = abi
+                    self.source_code = source_code
+                    self.contract_name = contract_name
+
+            contract_info = ContractInfo(
+                abi=source_info.get('abi', []),
+                source_code=source_info.get('source_code', ''),
+                contract_name=source_info.get('contract_name', 'Unknown')
+            )
+
+        state_snapshot = await self._capture_state_snapshot(contract_info) if contract_info else {}
+        source_hash = hashlib.sha256(source_info.get('source_code', '').encode()).hexdigest()
+        state_hash = hashlib.sha256(json.dumps(state_snapshot.get('state_data', {}), sort_keys=True).encode()).hexdigest()
+
+        if self.result_storage:
+            cached_id = await self.result_storage.get_cached_result_id(target_contract, chain, source_hash, state_hash)
+            if cached_id and not force:
+                logger.info(f"Cache hit for {target_contract} on {chain}")
+                if reuse:
+                    cached_result = await self.result_storage.load_result(cached_id)
+                    if cached_result:
+                        cached_result['cached'] = True
+                        cached_result['source_hash'] = source_hash
+                        cached_result['state_hash'] = state_hash
+                        return cached_result
+                return {
+                    'cached': True,
+                    'source_hash': source_hash,
+                    'state_hash': state_hash,
+                    'success': True,
+                    'strategies': [],
+                    'exploits': [],
+                    'total_profit_potential': 0.0,
+                    'confidence_score': 1.0,
+                    'iterations_used': 0,
+                    'detailed_results': {}
+                }
+
         logger.info(f"Starting full A1 analysis for {target_contract}")
-        
+
         iteration_results = []
-        
+
         for iteration in range(1, self.max_iterations + 1):
             logger.info(f"Executing iteration {iteration}/{self.max_iterations}")
-            
+
             iteration_budget = int(
-                self.base_budget_per_iteration * 
+                self.base_budget_per_iteration *
                 (self.diminishing_factor ** (iteration - 1))
             )
-            
+
             self.state.current_iteration = iteration
             self.state.iteration_budgets.append(iteration_budget)
-            
+
             result = await self._execute_iteration(iteration, iteration_budget)
             iteration_results.append(result)
-            
+
             self.state.total_budget_used += result.token_usage.get('total_tokens', 0)
             self.state.confidence_progression.append(result.confidence_score)
             self.state.findings_history.append(result.findings)
-            
+
             if self._should_terminate_early(iteration_results):
                 logger.info(f"Early termination at iteration {iteration}")
                 break
-            
+
             await asyncio.sleep(1)
-        
+
         final_analysis = await self._generate_final_analysis(iteration_results)
-        
+
         logger.info(f"Completed A1 analysis for {target_contract}")
-        return final_analysis
+        return {
+            'success': True,
+            'strategies': [asdict(s) for s in self.state.strategies_generated],
+            'exploits': [],
+            'total_profit_potential': sum(s.expected_profit_usd for s in self.state.strategies_generated),
+            'confidence_score': final_analysis.get('session_summary', {}).get('final_confidence', 0.0),
+            'iterations_used': len(iteration_results),
+            'detailed_results': final_analysis,
+            'source_hash': source_hash,
+            'state_hash': state_hash
+        }
     
     async def _execute_iteration(self, iteration_number: int, budget: int) -> IterationResult:
         """

--- a/main.py
+++ b/main.py
@@ -77,6 +77,8 @@ class ExecutionResult:
     confidence_score: float
     error_message: Optional[str] = None
     detailed_results: Dict[str, Any] = None
+    source_hash: Optional[str] = None
+    state_hash: Optional[str] = None
 
 class ContractProcessor:
     """
@@ -113,14 +115,17 @@ class ContractProcessor:
         self.result_storage: Optional[ResultStorage] = None
         self.metrics_collector: Optional[MetricsCollector] = None
         self.system_logger: Optional[SystemLogger] = None
-        
+
         self.is_initialized = False
         self.active_sessions: Dict[str, Dict[str, Any]] = {}
-        
+
         self.total_contracts_processed = 0
         self.successful_analyses = 0
         self.total_exploits_found = 0
         self.total_execution_time = 0.0
+
+        self.force_analysis = False
+        self.reuse_cache = False
     
     async def initialize(self):
         """Initialize all system components."""
@@ -153,8 +158,8 @@ class ContractProcessor:
             self.feedback_processor = FeedbackProcessor(self.config)
             self.strategy_generator = StrategyGenerator(self.config)
             self.orchestrator = ToolOrchestrator(self.tools, self.config)
-            
-            self.agent = A1Agent(self.config)
+
+            self.agent = A1Agent(self.config, self.result_storage)
             
             self.is_initialized = True
             logger.info("A1 Agentic System initialized successfully")
@@ -369,7 +374,10 @@ class ContractProcessor:
         try:
             logger.info(f"Phase 1: Initial analysis for {contract_target.address}")
             initial_analysis = await self.agent.execute_full_analysis(
-                contract_target.address, contract_target.network
+                contract_target.address,
+                contract_target.network,
+                force=self.force_analysis,
+                reuse=self.reuse_cache
             )
             
             if not initial_analysis.get("success", False):
@@ -392,21 +400,24 @@ class ContractProcessor:
             best_confidence = initial_analysis.get("confidence_score", 0.0)
             iterations_used = initial_analysis.get("iterations_used", 1)
             
-            logger.info(f"Phase 3: Final analysis for {contract_target.address}")
-            
-            final_analysis = await self._perform_final_analysis(session)
-            
+            if 'detailed_results' in initial_analysis:
+                final_analysis = initial_analysis["detailed_results"]
+            else:
+                logger.info(f"Phase 3: Final analysis for {contract_target.address}")
+                final_analysis = await self._perform_final_analysis(session)
             return ExecutionResult(
                 contract_address=contract_target.address,
                 network=contract_target.network,
                 success=exploits_found > 0,
                 execution_time=0.0,  # Will be set by caller
-                iterations_used=session["metrics"]["iterations"],
+                iterations_used=iterations_used,
                 strategies_generated=strategies_generated,
                 exploits_found=exploits_found,
                 total_profit_potential=total_profit_potential,
                 confidence_score=best_confidence,
-                detailed_results=final_analysis
+                detailed_results=final_analysis,
+                source_hash=initial_analysis.get("source_hash"),
+                state_hash=initial_analysis.get("state_hash")
             )
             
         except Exception as e:
@@ -540,7 +551,15 @@ class ContractProcessor:
     async def _store_execution_result(self, session_id: str, result: ExecutionResult):
         """Store execution result in persistent storage."""
         try:
-            await self.result_storage.store_result(session_id, result)
+            result_id = await self.result_storage.store_result(session_id, result)
+            if result.source_hash and result.state_hash:
+                await self.result_storage.update_contract_cache(
+                    result.contract_address,
+                    result.network,
+                    result.source_hash,
+                    result.state_hash,
+                    result_id
+                )
             logger.info(f"Stored execution result for session {session_id}")
         except Exception as e:
             logger.error(f"Failed to store execution result: {e}")
@@ -703,6 +722,8 @@ async def main():
     parser.add_argument('--max-concurrent', type=int, default=3, help='Maximum concurrent executions')
     parser.add_argument('--output', '-o', help='Output file for results')
     parser.add_argument('--verbose', '-v', action='store_true', help='Verbose logging')
+    parser.add_argument('--force', action='store_true', help='Force re-analysis even if cache is valid')
+    parser.add_argument('--reuse', action='store_true', help='Reuse cached results when available')
     
     args = parser.parse_args()
     
@@ -713,10 +734,13 @@ async def main():
     config = config_manager.get_config()
     
     processor = ContractProcessor(config)
-    
+
     try:
         await processor.initialize()
-        
+
+        processor.force_analysis = args.force
+        processor.reuse_cache = args.reuse
+
         targets = []
         
         if args.contract:

--- a/main.py
+++ b/main.py
@@ -79,6 +79,7 @@ class ExecutionResult:
     detailed_results: Dict[str, Any] = None
     source_hash: Optional[str] = None
     state_hash: Optional[str] = None
+    cached_result_id: Optional[str] = None
 
 class ContractProcessor:
     """
@@ -379,6 +380,8 @@ class ContractProcessor:
                 force=self.force_analysis,
                 reuse=self.reuse_cache
             )
+            cached_result_id = initial_analysis.get("cached_result_id")
+
             
             if not initial_analysis.get("success", False):
                 return ExecutionResult(
@@ -391,7 +394,8 @@ class ContractProcessor:
                     exploits_found=0,
                     total_profit_potential=0.0,
                     confidence_score=0.0,
-                    error_message="Contract analysis failed"
+                    error_message="Contract analysis failed",
+                    cached_result_id=cached_result_id,
                 )
             
             strategies_generated = len(initial_analysis.get("strategies", []))
@@ -417,7 +421,8 @@ class ContractProcessor:
                 confidence_score=best_confidence,
                 detailed_results=final_analysis,
                 source_hash=initial_analysis.get("source_hash"),
-                state_hash=initial_analysis.get("state_hash")
+                state_hash=initial_analysis.get("state_hash"),
+                cached_result_id=cached_result_id,
             )
             
         except Exception as e:
@@ -550,6 +555,9 @@ class ContractProcessor:
     
     async def _store_execution_result(self, session_id: str, result: ExecutionResult):
         """Store execution result in persistent storage."""
+        if result.cached_result_id:
+            logger.info(f"Skipping storage for {session_id}; using cached result {result.cached_result_id}")
+            return
         try:
             result_id = await self.result_storage.store_result(session_id, result)
             if result.source_hash and result.state_hash:

--- a/storage/result_storage.py
+++ b/storage/result_storage.py
@@ -158,7 +158,19 @@ class ResultStorage:
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
-        
+
+        await self.db.execute("""
+            CREATE TABLE IF NOT EXISTS contracts (
+                contract_address TEXT NOT NULL,
+                network TEXT NOT NULL,
+                source_hash TEXT NOT NULL,
+                state_hash TEXT NOT NULL,
+                result_id TEXT,
+                last_updated TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (contract_address, network)
+            )
+        """)
+
         await self.db.commit()
     
     async def _create_indexes(self):
@@ -169,7 +181,9 @@ class ResultStorage:
             "CREATE INDEX IF NOT EXISTS idx_results_timestamp ON execution_results (timestamp)",
             "CREATE INDEX IF NOT EXISTS idx_results_success ON execution_results (success)",
             "CREATE INDEX IF NOT EXISTS idx_exploits_result ON exploits (result_id)",
-            "CREATE INDEX IF NOT EXISTS idx_strategies_result ON strategies (result_id)"
+            "CREATE INDEX IF NOT EXISTS idx_strategies_result ON strategies (result_id)",
+            "CREATE INDEX IF NOT EXISTS idx_contracts_address ON contracts (contract_address)",
+            "CREATE INDEX IF NOT EXISTS idx_contracts_network ON contracts (network)"
         ]
         
         for index_sql in indexes:
@@ -272,6 +286,75 @@ class ResultStorage:
                 json.dumps(execution_result.get('execution_steps', [])),
                 execution_result.get('gas_estimate', 0)
             ))
+
+    async def get_cached_result_id(self, contract_address: str, network: str, source_hash: str, state_hash: str) -> Optional[str]:
+        """Get cached result ID for contract if hashes match."""
+        cursor = await self.db.execute(
+            "SELECT result_id FROM contracts WHERE contract_address=? AND network=? AND source_hash=? AND state_hash=?",
+            (contract_address, network, source_hash, state_hash)
+        )
+        row = await cursor.fetchone()
+        return row[0] if row else None
+
+    async def update_contract_cache(self, contract_address: str, network: str, source_hash: str, state_hash: str, result_id: str):
+        """Update contract cache with latest hashes and result reference."""
+        await self.db.execute(
+            """
+            INSERT INTO contracts (contract_address, network, source_hash, state_hash, result_id, last_updated)
+            VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(contract_address, network) DO UPDATE SET
+                source_hash=excluded.source_hash,
+                state_hash=excluded.state_hash,
+                result_id=excluded.result_id,
+                last_updated=CURRENT_TIMESTAMP
+            """,
+            (contract_address, network, source_hash, state_hash, result_id)
+        )
+        await self.db.commit()
+
+    async def load_result(self, result_id: str) -> Optional[Dict[str, Any]]:
+        """Load stored result and associated detailed data."""
+        cursor = await self.db.execute(
+            """
+            SELECT contract_address, network, success, execution_time, iterations_used,
+                   strategies_generated, exploits_found, total_profit_potential,
+                   confidence_score, error_message, detailed_results_path
+            FROM execution_results WHERE id = ?
+            """,
+            (result_id,)
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return None
+
+        detailed_results = {}
+        if row[10]:
+            try:
+                file_path = self.data_dir / row[10]
+                if self.compression_enabled and file_path.suffix == '.gz':
+                    with gzip.open(file_path, 'rt', encoding='utf-8') as f:
+                        detailed_results = json.load(f)
+                else:
+                    with open(file_path, 'r', encoding='utf-8') as f:
+                        detailed_results = json.load(f)
+            except Exception as e:
+                logger.error(f"Failed to load detailed results for {result_id}: {e}")
+
+        return {
+            'contract_address': row[0],
+            'network': row[1],
+            'success': bool(row[2]),
+            'execution_time': row[3],
+            'iterations_used': row[4],
+            'strategies_generated': row[5],
+            'exploits_found': row[6],
+            'total_profit_potential': row[7],
+            'confidence_score': row[8],
+            'error_message': row[9],
+            'detailed_results': detailed_results,
+            'strategies': detailed_results.get('generated_strategies', []) if isinstance(detailed_results, dict) else [],
+            'exploits': detailed_results.get('best_exploits', []) if isinstance(detailed_results, dict) else []
+        }
     
     async def get_statistics(self) -> Dict[str, Any]:
         """Get storage statistics."""


### PR DESCRIPTION
## Summary
- Track analyzed contracts in new `contracts` table keyed by address and chain, caching source and state hashes
- A1Agent checks cache to skip or reuse analysis when contract hasn't changed
- CLI options `--force` and `--reuse` allow overriding or reusing cached results

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*

------
https://chatgpt.com/codex/tasks/task_b_68b0b99e500083219c9ab2acfb5de522