### PR TITLE
Add Prometheus metrics and watchdog

### DIFF
--- a/core/orchestrator.py
+++ b/core/orchestrator.py
@@ -16,6 +16,9 @@ from enum import Enum
 import logging
 from concurrent.futures import ThreadPoolExecutor, as_completed
 import json
+from collections import defaultdict
+
+from monitoring.metrics import record_error, record_heartbeat, set_queue_depth
 
 logger = logging.getLogger(__name__)
 
@@ -95,6 +98,10 @@ class ToolOrchestrator:
         self.default_timeout = config.get('DEFAULT_TOOL_TIMEOUT', 300)  # 5 minutes
         self.max_retries = config.get('MAX_TOOL_RETRIES', 2)
         self.resource_budget = config.get('RESOURCE_BUDGET_PER_ITERATION', 1000)
+
+        self.watchdog_restart_limit = config.get('WATCHDOG_RESTART_LIMIT', 1)
+        self.watchdog_escalate_threshold = config.get('WATCHDOG_ESCALATE_THRESHOLD', 3)
+        self.tool_failure_counts = defaultdict(int)
         
         self.tool_metadata = self._initialize_tool_metadata()
         
@@ -662,6 +669,7 @@ class ToolOrchestrator:
         Returns:
             Workflow execution results
         """
+        record_heartbeat()
         logger.info(f"Executing workflow {workflow_plan.plan_id} with {len(workflow_plan.tool_executions)} tools")
         
         start_time = time.time()
@@ -669,6 +677,7 @@ class ToolOrchestrator:
         failed_executions = []
         
         for group_idx, parallel_group in enumerate(workflow_plan.parallel_groups):
+            set_queue_depth(len(workflow_plan.parallel_groups) - group_idx)
             logger.info(f"Executing parallel group {group_idx + 1}/{len(workflow_plan.parallel_groups)}: {parallel_group}")
             
             group_results = await self._execute_parallel_group(parallel_group, workflow_plan, context)
@@ -723,6 +732,7 @@ class ToolOrchestrator:
         Returns:
             Dictionary mapping tool names to execution results
         """
+        set_queue_depth(len(parallel_group))
         tasks = []
         
         for tool_name in parallel_group:
@@ -773,68 +783,86 @@ class ToolOrchestrator:
         return results
     
     async def _execute_single_tool(self, execution: ToolExecution, context: Dict[str, Any]) -> ExecutionResult:
-        """
-        Execute a single tool with retry logic and error handling.
-        
-        Args:
-            execution: Tool execution configuration
-            context: Execution context
-            
-        Returns:
-            Execution result
-        """
-        start_time = time.time()
-        last_error = None
-        
-        for attempt in range(execution.retry_count + 1):
-            try:
-                logger.debug(f"Executing {execution.tool_name}.{execution.method_name} (attempt {attempt + 1})")
-                
-                tool = self.tools.get(execution.tool_name)
-                if not tool:
-                    raise ValueError(f"Tool {execution.tool_name} not available")
-                
-                method = getattr(tool, execution.method_name, None)
-                if not method:
-                    raise ValueError(f"Method {execution.method_name} not found on {execution.tool_name}")
-                
-                result = await asyncio.wait_for(
-                    method(**execution.parameters),
-                    timeout=execution.timeout
+        """Execute a single tool with retry, restart and error tracking."""
+
+        for restart_attempt in range(self.watchdog_restart_limit + 1):
+            start_time = time.time()
+            last_error = None
+
+            for attempt in range(execution.retry_count + 1):
+                try:
+                    logger.debug(
+                        f"Executing {execution.tool_name}.{execution.method_name} "
+                        f"(attempt {attempt + 1}, restart {restart_attempt})"
+                    )
+
+                    tool = self.tools.get(execution.tool_name)
+                    if not tool:
+                        raise ValueError(f"Tool {execution.tool_name} not available")
+
+                    method = getattr(tool, execution.method_name, None)
+                    if not method:
+                        raise ValueError(f"Method {execution.method_name} not found on {execution.tool_name}")
+
+                    result = await asyncio.wait_for(
+                        method(**execution.parameters),
+                        timeout=execution.timeout,
+                    )
+
+                    execution_time = time.time() - start_time
+
+                    resource_usage = {
+                        'cost': execution.estimated_cost,
+                        'execution_time': execution_time,
+                        'memory_usage': 0,  # Would be measured in real implementation
+                        'api_calls': 1,
+                    }
+
+                    return ExecutionResult(
+                        tool_name=execution.tool_name,
+                        method_name=execution.method_name,
+                        success=True,
+                        result=result,
+                        execution_time=execution_time,
+                        resource_usage=resource_usage,
+                        retry_attempts=attempt,
+                    )
+
+                except asyncio.TimeoutError:
+                    last_error = f"Execution timeout after {execution.timeout}s"
+                    record_error()
+                    logger.warning(
+                        f"{execution.tool_name}.{execution.method_name} timed out "
+                        f"(attempt {attempt + 1}, restart {restart_attempt})"
+                    )
+
+                except Exception as e:
+                    last_error = str(e)
+                    record_error()
+                    logger.warning(
+                        f"{execution.tool_name}.{execution.method_name} failed: {e} "
+                        f"(attempt {attempt + 1}, restart {restart_attempt})"
+                    )
+
+                if attempt < execution.retry_count:
+                    await asyncio.sleep(1.0 * (attempt + 1))  # Exponential backoff
+
+            # After retry attempts exhausted
+            self.tool_failure_counts[execution.tool_name] += 1
+            if self.tool_failure_counts[execution.tool_name] >= self.watchdog_escalate_threshold:
+                self._escalate_failure(execution.tool_name, last_error)
+                break
+
+            if restart_attempt < self.watchdog_restart_limit:
+                logger.info(
+                    f"Watchdog restarting {execution.tool_name} after failure"
                 )
-                
-                execution_time = time.time() - start_time
-                
-                resource_usage = {
-                    'cost': execution.estimated_cost,
-                    'execution_time': execution_time,
-                    'memory_usage': 0,  # Would be measured in real implementation
-                    'api_calls': 1
-                }
-                
-                return ExecutionResult(
-                    tool_name=execution.tool_name,
-                    method_name=execution.method_name,
-                    success=True,
-                    result=result,
-                    execution_time=execution_time,
-                    resource_usage=resource_usage,
-                    retry_attempts=attempt
-                )
-                
-            except asyncio.TimeoutError:
-                last_error = f"Execution timeout after {execution.timeout}s"
-                logger.warning(f"{execution.tool_name}.{execution.method_name} timed out (attempt {attempt + 1})")
-                
-            except Exception as e:
-                last_error = str(e)
-                logger.warning(f"{execution.tool_name}.{execution.method_name} failed: {e} (attempt {attempt + 1})")
-            
-            if attempt < execution.retry_count:
-                await asyncio.sleep(1.0 * (attempt + 1))  # Exponential backoff
-        
+                self._restart_tool(execution.tool_name)
+                continue
+
+            break
+
         execution_time = time.time() - start_time
-        
         return ExecutionResult(
             tool_name=execution.tool_name,
             method_name=execution.method_name,
@@ -843,7 +871,7 @@ class ToolOrchestrator:
             execution_time=execution_time,
             resource_usage={'cost': 0},
             error_message=last_error,
-            retry_attempts=execution.retry_count
+            retry_attempts=execution.retry_count,
         )
     
     def _extract_context_updates(self, group_results: Dict[str, ExecutionResult]) -> Dict[str, Any]:
@@ -879,8 +907,32 @@ class ToolOrchestrator:
                         context_updates['fork_id'] = result.result
                     elif result.method_name == 'setup_forge_project':
                         context_updates['project_path'] = result.result
-        
+
         return context_updates
+
+    def _restart_tool(self, tool_name: str) -> None:
+        """Attempt to restart a tool after a failure."""
+
+        tool = self.tools.get(tool_name)
+        if not tool:
+            return
+        try:
+            if hasattr(tool, 'restart'):
+                tool.restart()
+            else:
+                tool_cls = tool.__class__
+                config = getattr(tool, 'config', {})
+                self.tools[tool_name] = tool_cls(**config) if config else tool_cls()
+            logger.info(f"Tool {tool_name} restarted by watchdog")
+        except Exception as e:
+            logger.error(f"Failed to restart tool {tool_name}: {e}")
+
+    def _escalate_failure(self, tool_name: str, error: Optional[str]) -> None:
+        """Escalate repeated tool failures for external handling."""
+
+        logger.critical(
+            f"Tool {tool_name} failed repeatedly: {error}. Escalating to supervisor"
+        )
     
     def _update_performance_metrics(self, execution_results: Dict[str, ExecutionResult]):
         """

--- a/deploy/Dockerfile
+++ b/deploy/Dockerfile
@@ -1,0 +1,15 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY . /app
+
+RUN apt-get update && apt-get install -y curl \
+    && rm -rf /var/lib/apt/lists/* \
+    && pip install --no-cache-dir -r requirements.txt
+
+EXPOSE 8000
+
+HEALTHCHECK --interval=30s --timeout=5s --start-period=30s CMD curl -f http://localhost:8000/metrics || exit 1
+
+CMD ["python", "main.py"]

--- a/deploy/kubernetes.yaml
+++ b/deploy/kubernetes.yaml
@@ -1,0 +1,34 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: a1-agent
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: a1-agent
+  template:
+    metadata:
+      labels:
+        app: a1-agent
+    spec:
+      restartPolicy: Always
+      containers:
+        - name: a1-agent
+          image: a1-agent:latest
+          ports:
+            - containerPort: 8000
+          livenessProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+            initialDelaySeconds: 30
+            periodSeconds: 30
+          readinessProbe:
+            httpGet:
+              path: /metrics
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 10
+          resources: {}
+          imagePullPolicy: IfNotPresent

--- a/main.py
+++ b/main.py
@@ -41,6 +41,7 @@ from storage.result_storage import ResultStorage
 from config.configuration_manager import ConfigurationManager
 from monitoring.logger import SystemLogger
 from monitoring.metrics_collector import MetricsCollector
+from monitoring.metrics import start_metrics_server
 
 logging.basicConfig(
     level=logging.INFO,
@@ -711,7 +712,10 @@ async def main():
     
     config_manager = ConfigurationManager(args.config)
     config = config_manager.get_config()
-    
+
+    # Start Prometheus metrics HTTP server for health checks
+    start_metrics_server()
+
     processor = ContractProcessor(config)
     
     try:

--- a/monitoring/metrics.py
+++ b/monitoring/metrics.py
@@ -1,10 +1,78 @@
-"""
-Metrics - A1 Agentic System
+"""Metrics - A1 Agentic System
 
-Performance metrics collection and monitoring system.
-Re-exports the MetricsCollector for the expected module structure.
+Prometheus metrics exports and simple helper functions used across the
+project.  The existing :class:`~monitoring.metrics_collector.MetricsCollector`
+is still re-exported for backwards compatibility, but this module now exposes
+runtime gauges and counters that can be scraped by Prometheus.
+
+The following metrics are provided:
+
+``heartbeat``
+    Timestamp of the last heartbeat emitted by the orchestrator.
+``queue_depth``
+    Number of tasks currently waiting for execution.
+``error_rate``
+    Rate of tool execution errors per second.
+``errors_total``
+    Counter of total tool execution errors.
+
+The ``start_metrics_server`` function should be called once on start-up to
+expose the ``/metrics`` HTTP endpoint (default port ``8000``).
 """
+
+from __future__ import annotations
+
+import time
+from typing import Optional
+
+from prometheus_client import Counter, Gauge, start_http_server
 
 from .metrics_collector import MetricsCollector, MetricPoint
 
-__all__ = ['MetricsCollector', 'MetricPoint']
+_start_time = time.time()
+_error_count = 0
+
+heartbeat_gauge = Gauge("a1_heartbeat", "Last recorded heartbeat timestamp")
+queue_depth_gauge = Gauge("a1_queue_depth", "Current depth of the task queue")
+error_counter = Counter("a1_errors_total", "Total number of tool errors")
+error_rate_gauge = Gauge("a1_error_rate", "Tool error rate per second")
+
+
+def start_metrics_server(port: int = 8000) -> None:
+    """Start the Prometheus metrics HTTP server on the given ``port``."""
+
+    start_http_server(port)
+
+
+def record_heartbeat(timestamp: Optional[float] = None) -> None:
+    """Update the heartbeat metric with ``timestamp`` or the current time."""
+
+    heartbeat_gauge.set(timestamp or time.time())
+
+
+def set_queue_depth(depth: int) -> None:
+    """Set the current task queue ``depth`` metric."""
+
+    queue_depth_gauge.set(depth)
+
+
+def record_error() -> None:
+    """Increment error counters and update the error rate gauge."""
+
+    global _error_count
+    _error_count += 1
+    error_counter.inc()
+    elapsed = time.time() - _start_time
+    if elapsed > 0:
+        error_rate_gauge.set(_error_count / elapsed)
+
+
+__all__ = [
+    "MetricsCollector",
+    "MetricPoint",
+    "start_metrics_server",
+    "record_heartbeat",
+    "set_queue_depth",
+    "record_error",
+]
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,3 +21,4 @@ pytest-asyncio>=0.21.1
 black>=23.11.0
 flake8>=6.1.0
 mypy>=1.7.1
+prometheus_client>=0.16.0


### PR DESCRIPTION
## Summary
- export heartbeat, queue depth and error rate Prometheus metrics
- restart failed tools with watchdog and escalate repeated failures
- provide Docker and Kubernetes manifests with health probes

## Testing
- `pytest` *(fails: ModuleNotFoundError: No module named 'aiosqlite')*
- `flake8 monitoring/metrics.py core/orchestrator.py` *(fails: line too long and lint issues)*

------
https://chatgpt.com/codex/tasks/task_b_68b0b99f78288321b32a3eec1b443656