### PR TITLE
fix: derive per-account nonces when crafting mainnet txs

### DIFF
--- a/blockchain/forge.py
+++ b/blockchain/forge.py
@@ -590,30 +590,49 @@ contract ExploitTest is TestBase {
 
         from eth_account import Account
         from web3 import Web3
+        from blockchain.client import BlockchainClient, NetworkType
 
         network_cfg = self.networks.get(ForgeNetwork.ETHEREUM, {})
         chain_id = network_cfg.get('chain_id', 1)
         gas_price = network_cfg.get('gas_price', 0)
 
         signed_txs: List[str] = []
-        nonce_base = strategy.get('nonce', 0)
 
-        for idx, step in enumerate(strategy.get('execution_steps', [])):
-            tx = {
-                'to': step.get('to'),
-                'value': step.get('value', 0),
-                'data': step.get('data', '0x'),
-                'gas': step.get('gas', network_cfg.get('gas_limit', 21000)),
-                'gasPrice': step.get('gas_price', gas_price),
-                'nonce': step.get('nonce', nonce_base + idx),
-                'chainId': chain_id,
-            }
+        client = BlockchainClient(self.config)
+        nonces: Dict[str, int] = {}
+        try:
+            for key in private_keys:
+                acct = Account.from_key(key)
+                nonces[acct.address] = await client.get_transaction_count(
+                    NetworkType.ETHEREUM, acct.address
+                )
 
-            account = Account.from_key(private_keys[idx % len(private_keys)])
-            signed = account.sign_transaction(tx)
-            signed_txs.append(Web3.to_hex(signed.rawTransaction))
+            for idx, step in enumerate(strategy.get('execution_steps', [])):
+                key = private_keys[idx % len(private_keys)]
+                account = Account.from_key(key)
+                address = account.address
 
-        return signed_txs
+                nonce = step.get('nonce')
+                if nonce is None:
+                    nonce = nonces[address]
+                    nonces[address] += 1
+
+                tx = {
+                    'to': step.get('to'),
+                    'value': step.get('value', 0),
+                    'data': step.get('data', '0x'),
+                    'gas': step.get('gas', network_cfg.get('gas_limit', 21000)),
+                    'gasPrice': step.get('gas_price', gas_price),
+                    'nonce': nonce,
+                    'chainId': chain_id,
+                }
+
+                signed = account.sign_transaction(tx)
+                signed_txs.append(Web3.to_hex(signed.rawTransaction))
+
+            return signed_txs
+        finally:
+            await client.close()
     
     async def create_snapshot(self, project_name: str, snapshot_name: str) -> str:
         """


### PR DESCRIPTION
## Summary
- derive starting nonce for each signing account by querying the blockchain client

## Testing
- `pytest` *(fails: ImportError: cannot import name 'StateReader' from 'tools.state_reader')*

------
https://chatgpt.com/codex/tasks/task_b_68b0be5ca73883218a5b90888740618b