### PR TITLE
Add contract caching and force flag

### DIFF
--- a/core/agent.py
+++ b/core/agent.py
@@ -11,7 +11,8 @@ Based on the A1 research paper specifications.
 import asyncio
 import json
 import time
-from typing import Dict, List, Optional, Any, Tuple
+import hashlib
+from typing import Dict, List, Optional, Any, Tuple, Union
 from dataclasses import dataclass, asdict
 from enum import Enum
 import logging
@@ -27,6 +28,7 @@ from tools.state_reader import BlockchainStateReader
 from tools.code_sanitizer import CodeSanitizer
 from tools.concrete_execution import ConcreteExecutionTool
 from tools.revenue_normalizer import RevenueNormalizer
+from storage.result_storage import ResultStorage, StoredResult
 
 logger = logging.getLogger(__name__)
 
@@ -89,7 +91,7 @@ class A1Agent:
     through iterative refinement with 5-iteration budget management.
     """
     
-    def __init__(self, config: Dict[str, Any], queue: Optional[ContractQueue] = None):
+    def __init__(self, config: Dict[str, Any], queue: Optional[ContractQueue] = None, result_storage: Optional[ResultStorage] = None):
         """Initialize the A1 Agent.
 
         Parameters
@@ -104,6 +106,7 @@ class A1Agent:
 
         self.config = config
         self.queue = queue
+        self.result_storage = result_storage
 
         self.grok_client = AsyncOpenAI(
             api_key=config.get('GROK_API_KEY'),
@@ -129,6 +132,9 @@ class A1Agent:
             'execution_simulation': 1.0,
             'revenue_analysis': 0.9
         }
+
+        self.current_source_hash: Optional[str] = None
+        self.current_state_hash: Optional[str] = None
     
     def _initialize_tools(self) -> Dict[str, Any]:
         """Initialize all domain-specific tools."""
@@ -285,7 +291,7 @@ Provide final recommendations with confidence scores, profit projections, and ri
 """
         }
     
-    async def initialize_session(self, target_contract: Optional[str] = None, chain: str = 'ethereum') -> str:
+    async def initialize_session(self, target_contract: Optional[str] = None, chain: str = 'ethereum', force: bool = False) -> Union[str, StoredResult]:
         """Initialize a new exploit generation session.
 
         If ``target_contract`` is ``None`` the agent attempts to retrieve the
@@ -294,9 +300,10 @@ Provide final recommendations with confidence scores, profit projections, and ri
         Args:
             target_contract: Optional target contract address
             chain: Blockchain network ('ethereum' or 'bsc')
+            force: When True, bypass cache even if hashes match
 
         Returns:
-            Session ID for tracking
+            Session ID for tracking or a cached :class:`StoredResult`
         """
 
         if target_contract is None:
@@ -306,8 +313,32 @@ Provide final recommendations with confidence scores, profit projections, and ri
             target_contract = item.address
             chain = item.network
 
+        # Compute source and state hashes for caching
+        try:
+            fetcher: SourceCodeFetcher = self.tools['source_code_fetcher']
+            source_info = await fetcher.fetch_contract_source(target_contract)
+            self.current_source_hash = hashlib.sha256(source_info.source_code.encode()).hexdigest()
+
+            state_reader: BlockchainStateReader = self.tools['state_reader']
+            snapshot = await state_reader.capture_state_snapshot(target_contract, source_info.abi)
+            state_serialized = json.dumps(snapshot.state_data, sort_keys=True)
+            self.current_state_hash = hashlib.sha256(state_serialized.encode()).hexdigest()
+
+            if not force and self.result_storage:
+                cached = await self.result_storage.get_cached_result(
+                    target_contract,
+                    chain,
+                    self.current_source_hash,
+                    self.current_state_hash
+                )
+                if cached:
+                    logger.info(f"Using cached result for {target_contract} on {chain}")
+                    return cached
+        except Exception as e:
+            logger.debug(f"Cache lookup failed for {target_contract}: {e}")
+
         session_id = f"a1_{int(time.time())}_{target_contract[:8]}"
-        
+
         self.state = AgentState(
             current_iteration=0,
             current_phase=IterationPhase.RECONNAISSANCE,
@@ -320,11 +351,11 @@ Provide final recommendations with confidence scores, profit projections, and ri
             diminishing_returns_factor=1.0,
             session_start_time=int(time.time())
         )
-        
+
         logger.info(f"Initialized A1 session {session_id} for contract {target_contract}")
         return session_id
     
-    async def execute_full_analysis(self, target_contract: Optional[str] = None, chain: str = 'ethereum') -> Dict[str, Any]:
+    async def execute_full_analysis(self, target_contract: Optional[str] = None, chain: str = 'ethereum', force: bool = False) -> Union[Dict[str, Any], StoredResult]:
         """Execute the complete 5-iteration exploit generation process.
 
         When ``target_contract`` is ``None`` the agent will pull the next job
@@ -337,26 +368,31 @@ Provide final recommendations with confidence scores, profit projections, and ri
         Returns:
             Complete analysis results with generated strategies
         """
-        session_id = await self.initialize_session(target_contract, chain)
-        
+        init_result = await self.initialize_session(target_contract, chain, force)
+
+        if isinstance(init_result, StoredResult):
+            return init_result
+
+        session_id = init_result
+
         logger.info(f"Starting full A1 analysis for {target_contract}")
-        
+
         iteration_results = []
-        
+
         for iteration in range(1, self.max_iterations + 1):
             logger.info(f"Executing iteration {iteration}/{self.max_iterations}")
-            
+
             iteration_budget = int(
-                self.base_budget_per_iteration * 
+                self.base_budget_per_iteration *
                 (self.diminishing_factor ** (iteration - 1))
             )
-            
+
             self.state.current_iteration = iteration
             self.state.iteration_budgets.append(iteration_budget)
-            
+
             result = await self._execute_iteration(iteration, iteration_budget)
             iteration_results.append(result)
-            
+
             self.state.total_budget_used += result.token_usage.get('total_tokens', 0)
             self.state.confidence_progression.append(result.confidence_score)
             self.state.findings_history.append(result.findings)

--- a/main.py
+++ b/main.py
@@ -38,7 +38,7 @@ from blockchain.forge import ForgeIntegration
 
 from utils.dex_utils import DexRouter, TokenUtils
 
-from storage.result_storage import ResultStorage
+from storage.result_storage import ResultStorage, StoredResult
 from config.configuration_manager import ConfigurationManager
 from monitoring.logger import SystemLogger
 from monitoring.metrics_collector import MetricsCollector
@@ -78,6 +78,9 @@ class ExecutionResult:
     confidence_score: float
     error_message: Optional[str] = None
     detailed_results: Dict[str, Any] = None
+    source_hash: Optional[str] = None
+    state_hash: Optional[str] = None
+    cached: bool = False
 
 class ContractProcessor:
     """
@@ -155,7 +158,7 @@ class ContractProcessor:
             self.strategy_generator = StrategyGenerator(self.config)
             self.orchestrator = ToolOrchestrator(self.tools, self.config)
             
-            self.agent = A1Agent(self.config)
+            self.agent = A1Agent(self.config, result_storage=self.result_storage)
             
             self.is_initialized = True
             logger.info("A1 Agentic System initialized successfully")
@@ -216,7 +219,7 @@ class ContractProcessor:
                 logger.error(f"Failed to initialize tool {tool_name}: {e}")
                 raise
     
-    async def process_contract(self, contract_target: ContractTarget) -> ExecutionResult:
+    async def process_contract(self, contract_target: ContractTarget, force: bool = False) -> ExecutionResult:
         """
         Process a single contract for exploit analysis.
         
@@ -237,11 +240,12 @@ class ContractProcessor:
         try:
             session = await self._create_execution_session(session_id, contract_target)
             self.active_sessions[session_id] = session
-            
-            result = await self._execute_analysis_workflow(session_id, contract_target)
-            
-            await self._store_execution_result(session_id, result)
-            
+
+            result = await self._execute_analysis_workflow(session_id, contract_target, force)
+
+            if not result.cached:
+                await self._store_execution_result(session_id, result)
+
             self._update_performance_metrics(result)
             
             execution_time = time.time() - start_time
@@ -363,16 +367,33 @@ class ContractProcessor:
         
         return context
     
-    async def _execute_analysis_workflow(self, session_id: str, contract_target: ContractTarget) -> ExecutionResult:
+    async def _execute_analysis_workflow(self, session_id: str, contract_target: ContractTarget, force: bool = False) -> ExecutionResult:
         """Execute the main A1 analysis workflow."""
         session = self.active_sessions[session_id]
-        
+
         try:
             logger.info(f"Phase 1: Initial analysis for {contract_target.address}")
             initial_analysis = await self.agent.execute_full_analysis(
-                contract_target.address, contract_target.network
+                contract_target.address, contract_target.network, force=force
             )
-            
+
+            if isinstance(initial_analysis, StoredResult):
+                return ExecutionResult(
+                    contract_address=initial_analysis.contract_address,
+                    network=initial_analysis.network,
+                    success=initial_analysis.success,
+                    execution_time=0.0,
+                    iterations_used=initial_analysis.iterations_used,
+                    strategies_generated=initial_analysis.strategies_generated,
+                    exploits_found=initial_analysis.exploits_found,
+                    total_profit_potential=initial_analysis.total_profit_potential,
+                    confidence_score=initial_analysis.confidence_score,
+                    detailed_results=initial_analysis.detailed_results or {},
+                    source_hash=initial_analysis.source_hash,
+                    state_hash=initial_analysis.state_hash,
+                    cached=True,
+                )
+
             if not initial_analysis.get("success", False):
                 return ExecutionResult(
                     contract_address=contract_target.address,
@@ -384,19 +405,19 @@ class ContractProcessor:
                     exploits_found=0,
                     total_profit_potential=0.0,
                     confidence_score=0.0,
-                    error_message="Contract analysis failed"
+                    error_message="Contract analysis failed",
                 )
-            
+
             strategies_generated = len(initial_analysis.get("strategies", []))
             exploits_found = len(initial_analysis.get("exploits", []))
             total_profit_potential = initial_analysis.get("total_profit_potential", 0.0)
             best_confidence = initial_analysis.get("confidence_score", 0.0)
             iterations_used = initial_analysis.get("iterations_used", 1)
-            
+
             logger.info(f"Phase 3: Final analysis for {contract_target.address}")
-            
+
             final_analysis = await self._perform_final_analysis(session)
-            
+
             return ExecutionResult(
                 contract_address=contract_target.address,
                 network=contract_target.network,
@@ -407,13 +428,15 @@ class ContractProcessor:
                 exploits_found=exploits_found,
                 total_profit_potential=total_profit_potential,
                 confidence_score=best_confidence,
-                detailed_results=final_analysis
+                detailed_results=final_analysis,
+                source_hash=self.agent.current_source_hash,
+                state_hash=self.agent.current_state_hash,
             )
-            
+
         except Exception as e:
             logger.error(f"Analysis workflow failed for {contract_target.address}: {e}")
             raise
-    
+
     async def _perform_final_analysis(self, session: Dict[str, Any]) -> Dict[str, Any]:
         """Perform final analysis and generate comprehensive report."""
         try:
@@ -567,7 +590,7 @@ class ContractProcessor:
         except Exception as e:
             logger.warning(f"Failed to cleanup session {session_id}: {e}")
     
-    async def process_batch(self, contract_targets: List[ContractTarget], max_concurrent: int = 3) -> List[ExecutionResult]:
+    async def process_batch(self, contract_targets: List[ContractTarget], max_concurrent: int = 3, force: bool = False) -> List[ExecutionResult]:
         """
         Process multiple contracts concurrently.
         
@@ -588,7 +611,7 @@ class ContractProcessor:
         
         async def process_with_semaphore(target):
             async with semaphore:
-                return await self.process_contract(target)
+                return await self.process_contract(target, force=force)
         
         tasks = [process_with_semaphore(target) for target in contract_targets]
         
@@ -608,7 +631,7 @@ class ContractProcessor:
         logger.info(f"Batch processing completed: {len(results)} results")
         return results
 
-    async def process_queue(self, queue: ContractQueue, max_concurrent: int = 3) -> None:
+    async def process_queue(self, queue: ContractQueue, max_concurrent: int = 3, force: bool = False) -> None:
         """Continuously process contracts from a message queue.
 
         Args:
@@ -625,7 +648,7 @@ class ContractProcessor:
         async def handle(item: QueueItem):
             async with semaphore:
                 target = ContractTarget(address=item.address, network=item.network)
-                await self.process_contract(target)
+                await self.process_contract(target, force=force)
 
         try:
             async for item in queue.consume():
@@ -735,6 +758,7 @@ async def main():
     parser.add_argument('--max-concurrent', type=int, default=3, help='Maximum concurrent executions')
     parser.add_argument('--output', '-o', help='Output file for results')
     parser.add_argument('--verbose', '-v', action='store_true', help='Verbose logging')
+    parser.add_argument('--force', action='store_true', help='Force re-analysis even if cached results exist')
     
     args = parser.parse_args()
     
@@ -756,7 +780,7 @@ async def main():
                 name=f"Manual_{args.contract[:8]}"
             )
             logger.info("Processing single contract...")
-            result = await processor.process_contract(target)
+            result = await processor.process_contract(target, force=args.force)
 
             if args.output:
                 output_data = {
@@ -778,7 +802,7 @@ async def main():
         await queue.connect()
 
         logger.info("Processing contracts from queue... press Ctrl+C to stop")
-        await processor.process_queue(queue, args.max_concurrent)
+        await processor.process_queue(queue, args.max_concurrent, force=args.force)
         return 0
         
     except KeyboardInterrupt:

--- a/storage/result_storage.py
+++ b/storage/result_storage.py
@@ -40,6 +40,8 @@ class StoredResult:
     error_message: Optional[str]
     detailed_results: Optional[Dict[str, Any]]
     session_data: Optional[Dict[str, Any]]
+    source_hash: Optional[str] = None
+    state_hash: Optional[str] = None
 
 class ResultStorage:
     """
@@ -77,7 +79,8 @@ class ResultStorage:
         """Initialize the storage system."""
         try:
             self.db = await aiosqlite.connect(self.db_path)
-            
+            self.db.row_factory = aiosqlite.Row
+
             await self.db.execute("PRAGMA journal_mode=WAL")
             await self.db.execute("PRAGMA synchronous=NORMAL")
             await self.db.execute("PRAGMA cache_size=10000")
@@ -158,7 +161,19 @@ class ResultStorage:
                 created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
             )
         """)
-        
+
+        await self.db.execute("""
+            CREATE TABLE IF NOT EXISTS contracts (
+                address TEXT NOT NULL,
+                network TEXT NOT NULL,
+                source_hash TEXT NOT NULL,
+                state_hash TEXT NOT NULL,
+                result_id TEXT,
+                updated_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (address, network)
+            )
+        """)
+
         await self.db.commit()
     
     async def _create_indexes(self):
@@ -169,14 +184,15 @@ class ResultStorage:
             "CREATE INDEX IF NOT EXISTS idx_results_timestamp ON execution_results (timestamp)",
             "CREATE INDEX IF NOT EXISTS idx_results_success ON execution_results (success)",
             "CREATE INDEX IF NOT EXISTS idx_exploits_result ON exploits (result_id)",
-            "CREATE INDEX IF NOT EXISTS idx_strategies_result ON strategies (result_id)"
+            "CREATE INDEX IF NOT EXISTS idx_strategies_result ON strategies (result_id)",
+            "CREATE INDEX IF NOT EXISTS idx_contracts_network ON contracts (network)"
         ]
         
         for index_sql in indexes:
             await self.db.execute(index_sql)
         
         await self.db.commit()
-    
+
     async def store_result(self, session_id: str, result) -> str:
         """
         Store execution result.
@@ -215,7 +231,16 @@ class ResultStorage:
             
             if result.detailed_results and 'best_exploits' in result.detailed_results:
                 await self._store_exploits(result_id, result.detailed_results['best_exploits'])
-            
+
+            if getattr(result, 'source_hash', None) and getattr(result, 'state_hash', None):
+                await self.upsert_contract(
+                    result.contract_address,
+                    result.network,
+                    result.source_hash,
+                    result.state_hash,
+                    result_id
+                )
+
             await self.db.commit()
             
             self.total_stored += 1
@@ -250,7 +275,7 @@ class ResultStorage:
             
         except Exception as e:
             logger.error(f"Failed to store detailed data for {result_id}: {e}")
-            return None
+        return None
     
     async def _store_exploits(self, result_id: str, exploits: List[Dict[str, Any]]):
         """Store exploit details."""
@@ -272,6 +297,86 @@ class ResultStorage:
                 json.dumps(execution_result.get('execution_steps', [])),
                 execution_result.get('gas_estimate', 0)
             ))
+
+    async def upsert_contract(self, address: str, network: str, source_hash: str, state_hash: str, result_id: str):
+        """Insert or update contract cache entry."""
+        await self.db.execute(
+            """
+            INSERT INTO contracts (address, network, source_hash, state_hash, result_id, updated_at)
+            VALUES (?, ?, ?, ?, ?, CURRENT_TIMESTAMP)
+            ON CONFLICT(address, network) DO UPDATE SET
+                source_hash=excluded.source_hash,
+                state_hash=excluded.state_hash,
+                result_id=excluded.result_id,
+                updated_at=CURRENT_TIMESTAMP
+            """,
+            (address, network, source_hash, state_hash, result_id),
+        )
+
+    async def get_result(self, result_id: str) -> Optional[StoredResult]:
+        """Retrieve stored result by ID."""
+        cursor = await self.db.execute(
+            """SELECT * FROM execution_results WHERE id = ?""",
+            (result_id,),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return None
+
+        detailed = await self._load_detailed_data(row[12]) if row[12] else None
+        session = await self._load_detailed_data(row[13]) if row[13] else None
+
+        contract_cursor = await self.db.execute(
+            "SELECT source_hash, state_hash FROM contracts WHERE address = ? AND network = ?",
+            (row[1], row[2]),
+        )
+        contract_row = await contract_cursor.fetchone()
+        source_hash = contract_row[0] if contract_row else None
+        state_hash = contract_row[1] if contract_row else None
+
+        return StoredResult(
+            id=row[0],
+            contract_address=row[1],
+            network=row[2],
+            timestamp=row[3],
+            success=bool(row[4]),
+            execution_time=row[5],
+            iterations_used=row[6],
+            strategies_generated=row[7],
+            exploits_found=row[8],
+            total_profit_potential=row[9],
+            confidence_score=row[10],
+            error_message=row[11],
+            detailed_results=detailed,
+            session_data=session,
+            source_hash=source_hash,
+            state_hash=state_hash,
+        )
+
+    async def get_cached_result(self, address: str, network: str, source_hash: str, state_hash: str) -> Optional[StoredResult]:
+        """Get cached result if hashes match."""
+        cursor = await self.db.execute(
+            """SELECT result_id FROM contracts WHERE address = ? AND network = ? AND source_hash = ? AND state_hash = ?""",
+            (address, network, source_hash, state_hash),
+        )
+        row = await cursor.fetchone()
+        if not row:
+            return None
+        return await self.get_result(row[0])
+
+    async def _load_detailed_data(self, relative_path: str) -> Optional[Dict[str, Any]]:
+        """Load detailed data from file."""
+        try:
+            file_path = self.data_dir / relative_path
+            if file_path.suffix == '.gz':
+                with gzip.open(file_path, 'rt', encoding='utf-8') as f:
+                    return json.load(f)
+            else:
+                with open(file_path, 'r', encoding='utf-8') as f:
+                    return json.load(f)
+        except Exception as e:
+            logger.error(f"Failed to load detailed data from {relative_path}: {e}")
+            return None
     
     async def get_statistics(self) -> Dict[str, Any]:
         """Get storage statistics."""


### PR DESCRIPTION
## Summary
- Cache contract analysis by storing hashes in a new `contracts` table
- Reuse cached results in `A1Agent` unless `--force` flag is provided
- Expose `--force` CLI option to bypass cache

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ScannerIntegration')*


------
https://chatgpt.com/codex/tasks/task_b_68b0bf70681883218d5cc22d9d704bbb