### PR TITLE
Add shutdown support and queue maxsize to RequestManager

### DIFF
--- a/tests/unit/test_request_manager.py
+++ b/tests/unit/test_request_manager.py
@@ -14,3 +14,26 @@ async def test_queue_maxsize_and_shutdown():
     assert worker.task.done()
     assert worker.session is not None and worker.session.closed
     assert api_key not in RequestManager._workers
+
+
+@pytest.mark.asyncio
+async def test_shared_worker_lives_until_last_context():
+    api_key = "shared_key"
+    async with RequestManager(api_key) as rm1:
+        async with RequestManager(api_key) as rm2:
+            worker = rm1.worker
+            # Both managers should share the same worker instance
+            assert worker is rm2.worker
+        # After exiting rm2, worker should still be active
+        assert api_key in RequestManager._workers
+        worker_entry = RequestManager._workers[api_key]
+        assert worker_entry[0] is worker
+        assert worker_entry[1] == 1
+
+        async def dummy():
+            return "ok"
+
+        assert await rm1.call(dummy) == "ok"
+    # After exiting rm1, worker should be shut down
+    assert worker.task.done()
+    assert api_key not in RequestManager._workers

--- a/utils/request_manager.py
+++ b/utils/request_manager.py
@@ -13,7 +13,9 @@ class RequestManager:
     generic function calls in addition to standard HTTP requests.
     """
 
-    _workers: Dict[str, "_RequestWorker"] = {}
+    # Tracks active workers per API key along with reference counts.
+    # Each entry maps an API key to a tuple of (_RequestWorker, ref_count).
+    _workers: Dict[str, Tuple["_RequestWorker", int]] = {}
 
     def __init__(self, api_key: str,
                  max_requests_per_second: int = 5,
@@ -23,17 +25,25 @@ class RequestManager:
         self.max_requests_per_second = max_requests_per_second
         self.max_batch_size = max_batch_size
         if self.api_key not in RequestManager._workers:
-            RequestManager._workers[self.api_key] = _RequestWorker(
+            worker = _RequestWorker(
                 max_requests_per_second, max_batch_size, maxsize=queue_maxsize
             )
-        self.worker = RequestManager._workers[self.api_key]
+            RequestManager._workers[self.api_key] = (worker, 1)
+        else:
+            worker, ref_count = RequestManager._workers[self.api_key]
+            RequestManager._workers[self.api_key] = (worker, ref_count + 1)
+        self.worker = worker
 
     async def __aenter__(self) -> "RequestManager":
         return self
 
     async def __aexit__(self, exc_type, exc, tb) -> None:
-        await self.worker.shutdown()
-        RequestManager._workers.pop(self.api_key, None)
+        worker, ref_count = RequestManager._workers.get(self.api_key, (self.worker, 0))
+        if ref_count <= 1:
+            await worker.shutdown()
+            RequestManager._workers.pop(self.api_key, None)
+        else:
+            RequestManager._workers[self.api_key] = (worker, ref_count - 1)
         return None
 
     async def get(self, url: str, **kwargs) -> Any:


### PR DESCRIPTION
## Summary
- allow configuring queue size for RequestManager workers
- add shutdown routine to cancel worker task and close session
- ensure RequestManager exits cleanly and add corresponding unit test
- reference count shared workers so one context can't cancel another's task

## Testing
- `PYTHONPATH=. pytest tests/unit/test_request_manager.py -q`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'aiosqlite'; ImportError: cannot import name 'ScannerIntegration'; ImportError: cannot import name 'StateReader')*

------
https://chatgpt.com/codex/tasks/task_b_68b0c45d86608321bfbd95325fc37eb3