### PR TITLE
Handle network-specific transaction crafting

### DIFF
--- a/blockchain/forge.py
+++ b/blockchain/forge.py
@@ -569,7 +569,7 @@ contract ExploitTest is TestBase {
             logger.error(f"Failed to simulate transaction: {e}")
             raise
 
-    async def craft_mainnet_tx(self, strategy: Any) -> Dict[str, Any]:
+    async def craft_mainnet_tx(self, strategy: Any, network: ForgeNetwork = ForgeNetwork.ETHEREUM) -> Dict[str, Any]:
         """Craft and sign a raw transaction for mainnet execution.
 
         This helper constructs a basic transaction from an ``ExploitStrategy``
@@ -582,6 +582,8 @@ contract ExploitTest is TestBase {
                 minimum an ``execution_steps`` entry.  Only the first step is
                 used which should provide ``to``, ``data`` and optional
                 ``value`` fields.
+            network: Target network for transaction parameters. Defaults to
+                :class:`ForgeNetwork.ETHEREUM`.
 
         Returns:
             Dict containing the signed raw transaction and metadata.
@@ -612,7 +614,7 @@ contract ExploitTest is TestBase {
         data = first_step.get('data', '0x')
         value = int(first_step.get('value', 0))
 
-        network_cfg = self.networks.get(ForgeNetwork.ETHEREUM)
+        network_cfg = self.networks.get(network)
         gas = network_cfg["gas_limit"]
         gas_price = network_cfg["gas_price"]
         chain_id = network_cfg["chain_id"]

--- a/core/agent.py
+++ b/core/agent.py
@@ -29,7 +29,7 @@ from tools.code_sanitizer import CodeSanitizer
 from tools.concrete_execution import ConcreteExecutionTool
 from tools.revenue_normalizer import RevenueNormalizer
 from blockchain.client import NetworkType, BlockchainClient
-from blockchain.forge import ForgeIntegration
+from blockchain.forge import ForgeIntegration, ForgeNetwork
 from storage.result_storage import ResultStorage, StoredResult
 
 logger = logging.getLogger(__name__)
@@ -435,14 +435,30 @@ Provide final recommendations with confidence scores, profit projections, and ri
                         key=lambda s: s.confidence_score
                     )
                     if best_strategy.confidence_score >= self.confidence_threshold:
-                        tx = await self.forge.craft_mainnet_tx(best_strategy)
-                        network = NetworkType.ETHEREUM if self.state.network == 'ethereum' else NetworkType.BSC
-                        tx_hash = await self.blockchain_client.send_raw_transaction(network, tx['raw_tx'])
-                        final_analysis['execution_tx'] = tx_hash
-                        if self.result_storage and self.session_id:
-                            await self.result_storage.record_transaction_outcome(
-                                self.session_id, tx_hash, True,
-                                {'strategy_id': best_strategy.strategy_id}
+                        forge_network: Optional[ForgeNetwork]
+                        network: Optional[NetworkType]
+                        if self.state.network == 'ethereum':
+                            forge_network = ForgeNetwork.ETHEREUM
+                            network = NetworkType.ETHEREUM
+                        elif self.state.network == 'bsc':
+                            forge_network = ForgeNetwork.BSC
+                            network = NetworkType.BSC
+                        else:
+                            forge_network = None
+                            network = None
+
+                        if forge_network and network:
+                            tx = await self.forge.craft_mainnet_tx(best_strategy, forge_network)
+                            tx_hash = await self.blockchain_client.send_raw_transaction(network, tx['raw_tx'])
+                            final_analysis['execution_tx'] = tx_hash
+                            if self.result_storage and self.session_id:
+                                await self.result_storage.record_transaction_outcome(
+                                    self.session_id, tx_hash, True,
+                                    {'strategy_id': best_strategy.strategy_id}
+                                )
+                        else:
+                            logger.info(
+                                f"Skipping transaction crafting for unsupported network: {self.state.network}"
                             )
         except Exception as e:  # pragma: no cover - network operations
             logger.error(f"Failed to execute validated strategy: {e}")


### PR DESCRIPTION
## Summary
- allow forging helper to craft transactions for specified networks
- skip sending transactions when analysis network is unsupported

## Testing
- `pytest -q` *(fails: TypeError: '<=' not supported between instances...)*

------
https://chatgpt.com/codex/tasks/task_b_68b0c4adad888321b29c3f41a91649b0