### PR TITLE
Fix watchdog restart loop

### DIFF
--- a/monitoring/watchdog.py
+++ b/monitoring/watchdog.py
@@ -64,6 +64,10 @@ class WorkerWatchdog:
         thread = threading.Thread(target=self.worker_fn, daemon=True)
         thread.start()
         self._worker_thread = thread
+        # Reset heartbeat so the new worker has a full stall window to report
+        # liveness. Without this, the watchdog may immediately restart the
+        # worker again using the stale timestamp from the previous run.
+        self.metrics.record_heartbeat(self.heartbeat_name)
         logger.info("worker started by watchdog")
 
     def _monitor(self) -> None:

--- a/tests/unit/test_monitoring.py
+++ b/tests/unit/test_monitoring.py
@@ -41,3 +41,23 @@ def test_watchdog_restarts_and_alerts():
 
     assert metrics.counters["watchdog_restarts"] >= 1
     assert metrics.counters["watchdog_alerts"] >= 1
+
+
+def test_watchdog_resets_heartbeat_on_restart():
+    metrics = MetricsCollector({"ENABLE_METRICS": True})
+    # Seed an old heartbeat value
+    metrics.record_heartbeat("worker")
+    old = metrics.get_last_heartbeat("worker")
+    time.sleep(0.01)
+
+    watchdog = WorkerWatchdog(
+        worker_fn=lambda: None,
+        metrics=metrics,
+        heartbeat_name="worker",
+    )
+
+    # Starting the worker should reset the heartbeat timestamp
+    watchdog._start_worker()
+    new = metrics.get_last_heartbeat("worker")
+
+    assert new > old


### PR DESCRIPTION
## Summary
- reset watchdog heartbeat when (re)starting a worker so it gets a full stall window
- add test covering heartbeat reset on worker restart

## Testing
- `pytest -q` *(fails: ImportError: cannot import name 'ScannerIntegration' / 'StateReader')*
- `PYTHONPATH=. pytest tests/unit/test_monitoring.py -q`


------
https://chatgpt.com/codex/tasks/task_b_68b0c4bb839883218da303f65a70cd7a